### PR TITLE
Adds parsing for some nuts configuration fields

### DIFF
--- a/nuts/nuts.go
+++ b/nuts/nuts.go
@@ -62,11 +62,12 @@ func sanitizeProperties(configMap map[string]interface{}) map[string]interface{}
 	// int64 types
 	for _, iteration := range []string{"SegmentSize", "NodeNum", "CleanFdsCacheThreshold", "CommitBufferSize", "MaxBatchCount", "MaxBatchSize", "MaxWriteRecordCount"} {
 		if v := configMap[iteration]; v != nil {
-			switch v.(type) {
-			case int64:
-				configMap[iteration] = v.(int64)
-			case string:
-				configMap[iteration], _ = strconv.ParseInt(v.(string), 10, 64)
+			if val, ok := v.(int64); ok {
+				configMap[iteration] = val
+			}
+
+			if val, ok := v.(string); ok {
+				configMap[iteration], _ = strconv.ParseInt(val, 10, 64)
 			}
 		}
 	}

--- a/nuts/nuts.go
+++ b/nuts/nuts.go
@@ -49,11 +49,12 @@ func sanitizeProperties(configMap map[string]interface{}) map[string]interface{}
 	// int types
 	for _, iteration := range []string{"MaxFdNumsInCache", "BufferSizeOfRecovery"} {
 		if v := configMap[iteration]; v != nil {
-			switch v.(type) {
-			case int:
-				configMap[iteration] = v.(int)
-			case string:
-				configMap[iteration], _ = strconv.Atoi(v.(string))
+			if val, ok := v.(int); ok {
+				configMap[iteration] = val
+			}
+
+			if val, ok := v.(string); ok {
+				configMap[iteration], _ = strconv.Atoi(val)
 			}
 		}
 	}

--- a/nuts/nuts.go
+++ b/nuts/nuts.go
@@ -73,13 +73,14 @@ func sanitizeProperties(configMap map[string]interface{}) map[string]interface{}
 	// time.Duration types
 	for _, iteration := range []string{"MergeInterval"} {
 		if v := configMap[iteration]; v != nil {
-			switch v.(type) {
-			case time.Duration:
-				configMap[iteration] = v.(time.Duration)
-			case string:
+			if val, ok := v.(time.Duration); ok {
+				configMap[iteration] = val
+			}
+
+			if val, ok := v.(string); ok {
 				var err error
-				if configMap["MergeInterval"], err = time.ParseDuration(v.(string)); err != nil {
-					i, _ := strconv.Atoi(v.(string))
+				if configMap["MergeInterval"], err = time.ParseDuration(val); err != nil {
+					i, _ := strconv.Atoi(val)
 					configMap["MergeInterval"] = time.Duration(i)
 				}
 			}

--- a/nuts/nuts.go
+++ b/nuts/nuts.go
@@ -49,7 +49,21 @@ func sanitizeProperties(configMap map[string]interface{}) map[string]interface{}
 
 	for _, iteration := range []string{"SegmentSize", "NodeNum", "MaxFdNumsInCache"} {
 		if v := configMap[iteration]; v != nil {
-			configMap[iteration], _ = v.(int64)
+			switch v.(type) {
+			case int64:
+				configMap[iteration] = v.(int64)
+			case string:
+				configMap[iteration], _ = strconv.Atoi(v.(string))
+			}
+		}
+	}
+
+	if v := configMap["MergeInterval"]; v != nil {
+		switch v.(type) {
+		case time.Duration:
+			configMap["MergeInterval"] = v.(time.Duration)
+		case string:
+			configMap["MergeInterval"], _ = time.ParseDuration(v.(string))
 		}
 	}
 


### PR DESCRIPTION
Realized that, at least with a Caddyfile, it's impossible to use some Nuts config fields. Here's a simple Caddyfile I was using as an example...

```
{
    debug
    cache {
        ttl 15s
        nuts {
            configuration {
                Dir /opt/caddy # This is the only value which appears to have been applied correctly
                EntryIdxMode 1
                RWMode 0
                SegmentSize 1024
                NodeNum 42
                SyncEnable true
                StartFileLoadingMode 1
                MergeInterval 1m
            }
        }
    }
}

http://localhost {
    route /hello {
        cache
        respond "hello"
    }

    route /any {
        cache
        respond "any"
    }
}

```

This change ensures that all configuration values (which can be expressed in caddyfile, at least) are used when provisioning the storer.

### Note: Breaking Change

This constitutes a breaking change for users of the Nuts storer, as previously-ignored configuration values will be applied. Users who had configured their Nuts configuration will see changes in performance/behavior if they upgrade to a release with these changes.