### PR TITLE
Improve redis eviction mechanisms using sorted sets

### DIFF
--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -150,3 +150,129 @@ func TestRedis_DeleteMany(t *testing.T) {
 		t.Error("The map should be empty")
 	}
 }
+
+func TestRedis_EvictExpiredMappingEntries(t *testing.T) {
+	client, err := getRedisInstance()
+	if err != nil {
+		t.Fatalf("Failed to create Redis instance: %v", err)
+	}
+
+	// Clean up before test
+	client.DeleteMany("*")
+
+	// Cast to access the EvictExpiredMappingEntries method
+	redisClient, ok := client.(*redis.Redis)
+	if !ok {
+		t.Fatal("Failed to cast to *redis.Redis")
+	}
+
+	// Test that EvictExpiredMappingEntries returns true (indicating it handles eviction)
+	result := redisClient.EvictExpiredMappingEntries()
+	if !result {
+		t.Error("EvictExpiredMappingEntries should return true")
+	}
+
+	// Clean up after test
+	client.DeleteMany("*")
+}
+
+func TestRedis_EvictExpiredMappingEntries_WithExpiredEntries(t *testing.T) {
+	client, err := getRedisInstance()
+	if err != nil {
+		t.Fatalf("Failed to create Redis instance: %v", err)
+	}
+
+	// Clean up before test
+	client.DeleteMany("*")
+
+	// Use SetMultiLevel to create a mapping entry with a short but valid duration
+	// This will add an entry to the IDX_TIMESTAMPS sorted set
+	baseKey := "test-evict-base"
+	variedKey := "test-evict-varied"
+	value := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\ntest body")
+
+	// Use 1 second duration - Redis requires at least 1 second for expiry
+	err = client.SetMultiLevel(baseKey, variedKey, value, nil, "", 1*time.Second, "test-real-key")
+	if err != nil {
+		t.Fatalf("Failed to set multi-level: %v", err)
+	}
+
+	// Verify the mapping was created
+	mappingKey := core.MappingKeyPrefix + baseKey
+	mappingValue := client.Get(mappingKey)
+	if len(mappingValue) == 0 {
+		t.Error("Mapping should have been created")
+	}
+
+	// Wait for the entry to expire (stale time = duration + stale, but stale is 0 in test)
+	time.Sleep(2 * time.Second)
+
+	// Cast to access the EvictExpiredMappingEntries method
+	redisClient, ok := client.(*redis.Redis)
+	if !ok {
+		t.Fatal("Failed to cast to *redis.Redis")
+	}
+
+	// Run eviction
+	result := redisClient.EvictExpiredMappingEntries()
+	if !result {
+		t.Error("EvictExpiredMappingEntries should return true")
+	}
+
+	// The mapping key should be deleted since it only had one entry
+	mappingValue = client.Get(mappingKey)
+	if len(mappingValue) != 0 {
+		t.Error("Mapping should have been deleted after eviction")
+	}
+
+	// Clean up after test
+	client.DeleteMany("*")
+}
+
+func TestRedis_EvictExpiredMappingEntries_NoExpiredEntries(t *testing.T) {
+	client, err := getRedisInstance()
+	if err != nil {
+		t.Fatalf("Failed to create Redis instance: %v", err)
+	}
+
+	// Clean up before test
+	client.DeleteMany("*")
+
+	// Use SetMultiLevel to create a mapping entry with a long duration
+	baseKey := "test-no-evict-base"
+	variedKey := "test-no-evict-varied"
+	value := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\ntest body")
+
+	err = client.SetMultiLevel(baseKey, variedKey, value, nil, "", 1*time.Hour, "test-real-key")
+	if err != nil {
+		t.Fatalf("Failed to set multi-level: %v", err)
+	}
+
+	// Verify the mapping was created
+	mappingKey := core.MappingKeyPrefix + baseKey
+	mappingValue := client.Get(mappingKey)
+	if len(mappingValue) == 0 {
+		t.Error("Mapping should have been created")
+	}
+
+	// Cast to access the EvictExpiredMappingEntries method
+	redisClient, ok := client.(*redis.Redis)
+	if !ok {
+		t.Fatal("Failed to cast to *redis.Redis")
+	}
+
+	// Run eviction - should not remove anything since entry hasn't expired
+	result := redisClient.EvictExpiredMappingEntries()
+	if !result {
+		t.Error("EvictExpiredMappingEntries should return true")
+	}
+
+	// The mapping should still exist
+	mappingValue = client.Get(mappingKey)
+	if len(mappingValue) == 0 {
+		t.Error("Mapping should still exist after eviction of non-expired entries")
+	}
+
+	// Clean up after test
+	client.DeleteMany("*")
+}


### PR DESCRIPTION
### Description

This PR implements an efficient mapping eviction mechanism for Redis storages to address [souin#671](https://github.com/darkweak/souin/issues/671).

#### Problem

The current `EvictMapping()` function in souin uses `SCAN IDX_*` to iterate over ALL mapping keys every minute. This O(N) operation becomes increasingly expensive as the number of cached entries grows, causing performance degradation in high-traffic environments.

#### Solution

Introduces a sorted set `IDX_TIMESTAMPS` that tracks mapping entries by their stale time, enabling O(log N + M) lookups where M is only the number of expired entries.

**Before:**
```
Every minute → SCAN IDX_* (iterates ALL keys) → Process each mapping
```

**After:**
```
Every minute → ZRANGEBYSCORE IDX_TIMESTAMPS -inf <now> (only expired entries) → Process only expired
```

#### Changes

**`redis/redis.go`** (rueidis client):
- Added `MappingTimestampIndex` constant (`IDX_TIMESTAMPS`)
- Added `mappingEntry` struct for JSON serialization
- Modified `SetMultiLevel()` to add entries to a sorted set with staleTime as score
- Added `EvictExpiredMappingEntries()` method using `ZRANGEBYSCORE`
- Added `removeExpiredEntryFromMapping()` helper

**`go-redis/go-redis.go`**:
- Same changes as above using the go-redis client API

**Tests added:**
- `TestRedis_EvictExpiredMappingEntries` - Basic functionality test
- `TestRedis_EvictExpiredMappingEntries_WithExpiredEntries` - Verifies expired entries are removed
- `TestRedis_EvictExpiredMappingEntries_NoExpiredEntries` - Verifies non-expired entries remain

#### Data Structure

The sorted set stores entries as:
- **Score**: Unix timestamp of staleTime
- **Member**: JSON `{"m":"IDX_basekey","v":"variedKey"}`

#### Companion PR

This PR requires a companion PR in the `souin` repository that:
1. Adds the `MappingEvictor` interface to `pkg/storage/types/types.go`
2. Updates `EvictMapping()` in `pkg/api/souin.go` to check for and use the interface