### PR TITLE
fix(core): resolve cache data truncation in readResponse

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/pierrec/lz4/v4"
@@ -55,23 +54,12 @@ func DecodeMapping(item []byte) (*StorageMapper, error) {
 	return mapping, e
 }
 
-var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
-
 func readResponse(data []byte, req *http.Request) (*http.Response, error) {
+	buf := new(bytes.Buffer)
 	reader := lz4.NewReader(bytes.NewBuffer(data))
-	buf := bufPool.Get().(*bytes.Buffer)
-
-	defer func() {
-		reader.Reset(buf)
-		buf.Reset()
-		bufPool.Put(buf)
-	}()
-
 	_, _ = reader.WriteTo(buf)
 
-	bufReader := bufio.NewReader(buf)
-
-	return http.ReadResponse(bufReader, req)
+	return http.ReadResponse(bufio.NewReader(buf), req)
 }
 
 func MappingElection(provider Storer, item []byte, req *http.Request, validator *Revalidator, logger Logger) (resultFresh *http.Response, resultStale *http.Response, e error) {


### PR DESCRIPTION
Remove sync.Pool buffer reuse in readResponse that caused cached data to be truncated. The pooled buffer was being reset and returned to the pool before the response body was fully read, since http.ReadResponse returns a response whose Body still references the underlying buffer.

Fixes #41