### PR TITLE
fix(badger): remove Close() from Reset to prevent DB closed error

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -345,10 +345,8 @@ func (provider *Badger) Init() error {
 func (provider *Badger) Reset() error {
 	if err := provider.DropAll(); err != nil {
 		provider.logger.Errorf("Impossible to reset the Badger DB, %v", err)
-	}
 
-	if err := provider.Close(); err != nil {
-		provider.logger.Errorf("Impossible to close the Badger DB, %v", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Reset() should only clear data, not close the DB connection. This fixes the issue where flush API causes "DB Closed" errors.