### PR TITLE
fix(storages): properly close connections and cleanup instance cache in Reset

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -343,13 +343,13 @@ func (provider *Badger) Init() error {
 
 // Reset method will reset or close provider.
 func (provider *Badger) Reset() error {
-	if err := provider.DropAll(); err != nil {
-		provider.logger.Errorf("Impossible to reset the Badger DB, %v", err)
+	var err error
+	// Close the DB connection
+	if provider.DB != nil {
+		err = provider.Close()
 	}
+	// Only delete this instance from the cache
+	enabledBadgerInstances.Delete(provider.Uuid())
 
-	if err := provider.Close(); err != nil {
-		provider.logger.Errorf("Impossible to close the Badger DB, %v", err)
-	}
-
-	return nil
+	return err
 }

--- a/nuts/nuts.go
+++ b/nuts/nuts.go
@@ -25,9 +25,10 @@ var nutsInstanceMap = sync.Map{}
 type Nuts struct {
 	*nutsdb.DB
 
-	stale  time.Duration
-	logger core.Logger
-	uuid   string
+	stale       time.Duration
+	logger      core.Logger
+	uuid        string
+	instanceKey string
 }
 
 const (
@@ -186,10 +187,11 @@ func Factory(nutsConfiguration core.CacheProvider, logger core.Logger, stale tim
 	}
 
 	instance := &Nuts{
-		DB:     database,
-		stale:  stale,
-		logger: logger,
-		uuid:   fmt.Sprintf("%s-%s", nutsOptions.Dir, stale),
+		DB:          database,
+		stale:       stale,
+		logger:      logger,
+		uuid:        fmt.Sprintf("%s-%s", nutsOptions.Dir, stale),
+		instanceKey: nutsOptions.Dir,
 	}
 	nutsInstanceMap.Store(nutsOptions.Dir, instance.DB)
 
@@ -413,7 +415,13 @@ func (provider *Nuts) Init() error {
 
 // Reset method will reset or close provider.
 func (provider *Nuts) Reset() error {
-	return provider.Update(func(tx *nutsdb.Tx) error {
-		return tx.DeleteBucket(1, bucket)
-	})
+	var err error
+	// Close the DB connection
+	if provider.DB != nil {
+		err = provider.Close()
+	}
+	// Only delete this instance from the cache
+	nutsInstanceMap.Delete(provider.instanceKey)
+
+	return err
 }

--- a/otter/otter.go
+++ b/otter/otter.go
@@ -17,9 +17,10 @@ import (
 
 // Otter provider type.
 type Otter struct {
-	cache  *otter.CacheWithVariableTTL[string, []byte]
-	stale  time.Duration
-	logger core.Logger
+	cache       *otter.CacheWithVariableTTL[string, []byte]
+	stale       time.Duration
+	logger      core.Logger
+	instanceKey int
 }
 
 var instanceMap = sync.Map{}
@@ -49,9 +50,10 @@ func Factory(otterCfg core.CacheProvider, logger core.Logger, stale time.Duratio
 		cache := instance.(otter.CacheWithVariableTTL[string, []byte])
 
 		return &Otter{
-			cache:  &cache,
-			stale:  stale,
-			logger: logger,
+			cache:       &cache,
+			stale:       stale,
+			logger:      logger,
+			instanceKey: defaultStorageSize,
 		}, nil
 	}
 
@@ -69,7 +71,7 @@ func Factory(otterCfg core.CacheProvider, logger core.Logger, stale time.Duratio
 	instanceMap.Store(defaultStorageSize, cache)
 	logger.Infof("otter.storage.size %d", defaultStorageSize)
 
-	return &Otter{cache: &cache, logger: logger, stale: stale}, nil
+	return &Otter{cache: &cache, logger: logger, stale: stale, instanceKey: defaultStorageSize}, nil
 }
 
 // Name returns the storer name.
@@ -230,6 +232,9 @@ func (provider *Otter) Init() error {
 // Reset method will reset or close provider.
 func (provider *Otter) Reset() error {
 	provider.cache.Clear()
+
+	// Only delete this instance from the cache
+	instanceMap.Delete(provider.instanceKey)
 
 	return nil
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -279,7 +279,9 @@ func (provider *Redis) Init() error {
 
 // Reset method will reset or close provider.
 func (provider *Redis) Reset() error {
-	_ = provider.inClient.Do(provider.ctx, provider.inClient.B().Flushdb().Build())
+	if provider.close != nil {
+		provider.close()
+	}
 
 	return nil
 }


### PR DESCRIPTION
- Badger, Nuts, Otter: delete only current instance from cache instead of all
- Badger, Nuts: close DB connection before removing from cache
- Redis: call close() instead of Flushdb()
- Add instanceKey field to Nuts and Otter for precise cache cleanup

This ensures proper cleanup on Caddy reload without data loss.

Relates:
- darkweak/souin#723
- darkweak/souin#722