### PR TITLE
fix(badger): coerce string scalars in configuration

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -22,44 +21,53 @@ import (
 	"go.uber.org/zap"
 )
 
-// sanitizeProperties coerces string scalars to the type of the badger.Options
-// field they address (Caddyfile dispensers tokenize every scalar as a string,
-// so numeric and boolean options would otherwise fail to unmarshal and be
-// dropped). Keys are matched to exported fields the same case-insensitive way
-// encoding/json matches them; unknown keys and unparsable values pass through
-// unchanged so the subsequent unmarshal reports them as before.
+// sanitizeProperties coerces string scalars to the numeric and boolean
+// badger.Options fields they address (Caddyfile dispensers tokenize every
+// scalar as a string, so those options would otherwise fail to unmarshal and
+// be dropped). Values that don't parse are left unchanged so the subsequent
+// unmarshal reports them as before.
 func sanitizeProperties(configMap map[string]interface{}) map[string]interface{} {
-	optionsType := reflect.TypeOf(badger.Options{})
-
-	for key, value := range configMap {
-		strValue, ok := value.(string)
-		if !ok {
-			continue
+	boolFields := []string{
+		"SyncWrites", "ReadOnly", "InMemory", "MetricsEnabled", "CompactL0OnClose",
+		"LmaxCompaction", "VerifyValueChecksum", "BypassLockGuard", "DetectConflicts",
+	}
+	for _, field := range boolFields {
+		if s, ok := configMap[field].(string); ok {
+			if v, err := strconv.ParseBool(s); err == nil {
+				configMap[field] = v
+			}
 		}
+	}
 
-		field, found := optionsType.FieldByNameFunc(func(name string) bool {
-			return strings.EqualFold(name, key)
-		})
-		if !found {
-			continue
+	intFields := []string{
+		"NumVersionsToKeep", "NumGoroutines", "LevelSizeMultiplier", "TableSizeMultiplier",
+		"MaxLevels", "MemTableSize", "BaseTableSize", "BaseLevelSize", "ValueThreshold",
+		"NumMemtables", "BlockSize", "BlockCacheSize", "IndexCacheSize", "NumLevelZeroTables",
+		"NumLevelZeroTablesStall", "ValueLogFileSize", "NumCompactors", "ZSTDCompressionLevel",
+		"EncryptionKeyRotationDuration", "NamespaceOffset", "ChecksumVerificationMode",
+	}
+	for _, field := range intFields {
+		if s, ok := configMap[field].(string); ok {
+			if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+				configMap[field] = v
+			}
 		}
+	}
 
-		switch field.Type.Kind() {
-		case reflect.Bool:
-			if v, err := strconv.ParseBool(strValue); err == nil {
-				configMap[key] = v
+	uintFields := []string{"ValueLogMaxEntries", "Compression", "ExternalMagicVersion"}
+	for _, field := range uintFields {
+		if s, ok := configMap[field].(string); ok {
+			if v, err := strconv.ParseUint(s, 10, 64); err == nil {
+				configMap[field] = v
 			}
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			if v, err := strconv.ParseInt(strValue, 10, 64); err == nil {
-				configMap[key] = v
-			}
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			if v, err := strconv.ParseUint(strValue, 10, 64); err == nil {
-				configMap[key] = v
-			}
-		case reflect.Float32, reflect.Float64:
-			if v, err := strconv.ParseFloat(strValue, 64); err == nil {
-				configMap[key] = v
+		}
+	}
+
+	floatFields := []string{"VLogPercentile", "BloomFalsePositive"}
+	for _, field := range floatFields {
+		if s, ok := configMap[field].(string); ok {
+			if v, err := strconv.ParseFloat(s, 64); err == nil {
+				configMap[field] = v
 			}
 		}
 	}

--- a/badger/badger.go
+++ b/badger/badger.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,6 +21,51 @@ import (
 	"github.com/pierrec/lz4/v4"
 	"go.uber.org/zap"
 )
+
+// sanitizeProperties coerces string scalars to the type of the badger.Options
+// field they address (Caddyfile dispensers tokenize every scalar as a string,
+// so numeric and boolean options would otherwise fail to unmarshal and be
+// dropped). Keys are matched to exported fields the same case-insensitive way
+// encoding/json matches them; unknown keys and unparsable values pass through
+// unchanged so the subsequent unmarshal reports them as before.
+func sanitizeProperties(configMap map[string]interface{}) map[string]interface{} {
+	optionsType := reflect.TypeOf(badger.Options{})
+
+	for key, value := range configMap {
+		strValue, ok := value.(string)
+		if !ok {
+			continue
+		}
+
+		field, found := optionsType.FieldByNameFunc(func(name string) bool {
+			return strings.EqualFold(name, key)
+		})
+		if !found {
+			continue
+		}
+
+		switch field.Type.Kind() {
+		case reflect.Bool:
+			if v, err := strconv.ParseBool(strValue); err == nil {
+				configMap[key] = v
+			}
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if v, err := strconv.ParseInt(strValue, 10, 64); err == nil {
+				configMap[key] = v
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if v, err := strconv.ParseUint(strValue, 10, 64); err == nil {
+				configMap[key] = v
+			}
+		case reflect.Float32, reflect.Float64:
+			if v, err := strconv.ParseFloat(strValue, 64); err == nil {
+				configMap[key] = v
+			}
+		}
+	}
+
+	return configMap
+}
 
 // Badger provider type.
 type Badger struct {
@@ -49,6 +96,10 @@ func Factory(badgerConfiguration core.CacheProvider, logger core.Logger, stale t
 
 	if badgerConfiguration.Configuration != nil {
 		var parsedBadger badger.Options
+
+		if configMap, ok := badgerConfiguration.Configuration.(map[string]interface{}); ok {
+			badgerConfiguration.Configuration = sanitizeProperties(configMap)
+		}
 
 		if b, e := json.Marshal(badgerConfiguration.Configuration); e == nil {
 			if e = json.Unmarshal(b, &parsedBadger); e != nil {

--- a/badger/badger_test.go
+++ b/badger/badger_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/darkweak/storages/badger"
 	"github.com/darkweak/storages/core"
+	dgraphbadger "github.com/dgraph-io/badger/v4"
 	"github.com/pierrec/lz4/v4"
 	"go.uber.org/zap"
 )
@@ -213,5 +214,24 @@ func TestFactoryCoercesStringScalarConfiguration(t *testing.T) {
 	}
 	if opts.VLogPercentile != 0.5 {
 		t.Errorf("expected VLogPercentile 0.5, got %f", opts.VLogPercentile)
+	}
+}
+
+// An unparsable scalar must be left untouched, not zeroed, so the default survives.
+func TestFactoryLeavesUnparsableScalarUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	instance, err := badger.Factory(core.CacheProvider{
+		Configuration: map[string]interface{}{
+			"Dir":           dir,
+			"ValueDir":      dir,
+			"NumCompactors": "not-a-number",
+		},
+	}, zap.NewNop().Sugar(), 0)
+	if err != nil {
+		t.Fatalf("Factory returned an error: %v", err)
+	}
+
+	if got, want := instance.(*badger.Badger).DB.Opts().NumCompactors, dgraphbadger.DefaultOptions(dir).NumCompactors; got != want {
+		t.Errorf("expected default NumCompactors %d preserved, got %d", want, got)
 	}
 }

--- a/badger/badger_test.go
+++ b/badger/badger_test.go
@@ -182,3 +182,36 @@ func TestBadger_SetMultiLevel_LargeValue(t *testing.T) {
 			len(largeValue), len(retrieved), float64(len(retrieved))/float64(len(largeValue))*100)
 	}
 }
+
+// Souin's Caddyfile parser tokenizes every configuration scalar as a string;
+// numeric and boolean badger options must still end up applied.
+func TestFactoryCoercesStringScalarConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	instance, err := badger.Factory(core.CacheProvider{
+		Configuration: map[string]interface{}{
+			"Dir":                dir,
+			"ValueDir":           dir,
+			"NumCompactors":      "2",
+			"BypassLockGuard":    "true",
+			"ValueLogMaxEntries": "500000",
+			"VLogPercentile":     "0.5",
+		},
+	}, zap.NewNop().Sugar(), 0)
+	if err != nil {
+		t.Fatalf("Factory returned an error: %v", err)
+	}
+
+	opts := instance.(*badger.Badger).DB.Opts()
+	if opts.NumCompactors != 2 {
+		t.Errorf("expected NumCompactors 2, got %d", opts.NumCompactors)
+	}
+	if !opts.BypassLockGuard {
+		t.Error("expected BypassLockGuard true, got false")
+	}
+	if opts.ValueLogMaxEntries != 500000 {
+		t.Errorf("expected ValueLogMaxEntries 500000, got %d", opts.ValueLogMaxEntries)
+	}
+	if opts.VLogPercentile != 0.5 {
+		t.Errorf("expected VLogPercentile 0.5, got %f", opts.VLogPercentile)
+	}
+}


### PR DESCRIPTION
Hi, I'd like to set `NumCompactors` via `Caddyfile` but that doesn't appear to work at the moment. Here is a solution Claude proposes, it looks good to me but I don't know much about this code base. Any chance you could review it and merge if OK, or alternatively, find a different solution that would let me achieve this?

By the way, there is a related issue where `SyncWrites` can't be set to false due to how `mergo.Merge` works, but that isn't addressed here. If you're accepting PRs I'd send that separately.

Below is Claude's proposal.

---

:robot: `Caddyfile` dispensers tokenize every scalar as a string, so numeric and boolean badger options (`NumCompactors`, `BypassLockGuard`, ...) failed to `json.Unmarshal` into `badger.Options` and were dropped with only a log line. The nuts and nats providers already sanitize their configuration maps for this; give badger the same treatment, deriving the coercion from `badger.Options`' field types via reflection instead of hand-listing field names.